### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/areas.h
+++ b/src/areas.h
@@ -27,7 +27,7 @@ double montecarlo(const std::vector<eulerr::Ellipse>& ellipses,
 
     for (size_t i = 0; i < n_points; ++i) {
       // sample points using Vogel's method
-      double theta = i*(PI*(3.0 - sqrt(5.0)));
+      double theta = i*(M_PI*(3.0 - sqrt(5.0)));
       double r = sqrt(static_cast<double>(i)/static_cast<double>(n_points));
 
       eulerr::Point p{r*cos(theta), r*sin(theta)};
@@ -73,15 +73,15 @@ double ellipse_segment(const eulerr::Ellipse& e,
   double theta1 = std::atan2(p1.k, p1.h);
 
   if (theta1 < theta0)
-    theta1 += 2.0*PI;
+    theta1 += 2.0*M_PI;
 
   // Triangle part of the sector
   double triangle = 0.5*std::abs(p1.h*p0.k - p0.h*p1.k);
 
   return
-    (theta1 - theta0) <= PI ? e.sector(theta1) - e.sector(theta0) - triangle
+    (theta1 - theta0) <= M_PI ? e.sector(theta1) - e.sector(theta0) - triangle
                             : e.area()
-                              - e.sector(theta0 + 2.0*PI)
+                              - e.sector(theta0 + 2.0*M_PI)
                               + e.sector(theta1)
                               + triangle;
 }

--- a/src/ellipse.h
+++ b/src/ellipse.h
@@ -11,7 +11,7 @@ struct Ellipse {
 
   double area() const
   {
-    return a*b*PI;
+    return a*b*M_PI;
   }
 
   // The code below is adapted from "The area of intersecting ellipses" by

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -99,8 +99,8 @@ inline Rcpp::NumericVector arma_to_rcpp(const T& x)
 template <typename T>
 inline T normalize_angle(T& x)
 {
-  T a = std::fmod(x + PI, 2.0*PI);
-  return a >= 0 ? (a - PI) : (a + PI);
+  T a = std::fmod(x + M_PI, 2.0*M_PI);
+  return a >= 0 ? (a - M_PI) : (a + M_PI);
 }
 
 template <typename T>

--- a/src/solver.h
+++ b/src/solver.h
@@ -29,8 +29,8 @@ inline arma::cx_vec solve_cubic(const double alpha,
   if (R*R < Q*Q*Q) {
     double theta = acos(R/sqrt(Q*Q*Q));
     y(0) = -2.0*sqrt(Q)*cos(theta/3.0) -  a/3.0;
-    y(1) = -2.0*sqrt(Q)*cos((theta + 2.0*PI)/3.0) - a/3.0;
-    y(2) = -2.0*sqrt(Q)*cos((theta - 2.0*PI)/3.0) - a/3.0;
+    y(1) = -2.0*sqrt(Q)*cos((theta + 2.0*M_PI)/3.0) - a/3.0;
+    y(2) = -2.0*sqrt(Q)*cos((theta - 2.0*M_PI)/3.0) - a/3.0;
   } else {
     double A = -signum(R)*cbrt(abs(R) + sqrt(R*R - Q*Q*Q));
     double B = nearly_equal(A, 0.0) ? 0.0 : Q/A;


### PR DESCRIPTION
Dear Johan, dear eulerr team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at RcppCore/Rcpp#1158 for motivation and history.

Your package uses PI (instead of the standard C define M_PI, or the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

As discussed in RcppCore/Rcpp#1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.