### PR TITLE
Fix for Mismatched Strips in Euler Diagram Facets

### DIFF
--- a/R/plot.euler.R
+++ b/R/plot.euler.R
@@ -546,7 +546,7 @@ plot.euler <- function(x,
                      name = "strip.top.vp",
                      layout = grid::grid.layout(nrow = 1, ncol = layout[2]))
 
-    lvls <- levels(strips$groups[[2]])
+    lvls <- levels(strips$groups[[ names(layout)[[2]] ]])
     n_lvls <- length(lvls)
     step <- 1/n_lvls
 
@@ -567,7 +567,7 @@ plot.euler <- function(x,
                      name = "strip.left.vp",
                      layout = grid::grid.layout(nrow = layout[1], ncol = 1))
 
-    lvls <- rev(levels(strips$groups[[1]]))
+    lvls <- rev(levels(strips$groups[[ names(layout)[[1]] ]]))
     n_lvls <- length(lvls)
     step <- 1/n_lvls
 

--- a/R/plot.euler.R
+++ b/R/plot.euler.R
@@ -567,7 +567,7 @@ plot.euler <- function(x,
                      name = "strip.left.vp",
                      layout = grid::grid.layout(nrow = layout[1], ncol = 1))
 
-    lvls <- levels(strips$groups[[1]])
+    lvls <- rev(levels(strips$groups[[1]]))
     n_lvls <- length(lvls)
     step <- 1/n_lvls
 

--- a/R/plot.euler.R
+++ b/R/plot.euler.R
@@ -546,7 +546,7 @@ plot.euler <- function(x,
                      name = "strip.top.vp",
                      layout = grid::grid.layout(nrow = 1, ncol = layout[2]))
 
-    lvls <- levels(strips$groups[[1]])
+    lvls <- levels(strips$groups[[2]])
     n_lvls <- length(lvls)
     step <- 1/n_lvls
 
@@ -567,7 +567,7 @@ plot.euler <- function(x,
                      name = "strip.left.vp",
                      layout = grid::grid.layout(nrow = layout[1], ncol = 1))
 
-    lvls <- levels(strips$groups[[2]])
+    lvls <- levels(strips$groups[[1]])
     n_lvls <- length(lvls)
     step <- 1/n_lvls
 


### PR DESCRIPTION

I encountered a problem with mismatched strips when using the `eulerr` package installed from CRAN. Here's the generated diagram:

![image](https://github.com/jolars/eulerr/assets/30854075/9be5738e-577c-4adb-b5d1-b3ed92e68b36)


Upon examining the source code of `eulerr`, I noticed an issue in the `plot.euler` method. The `pos` variable has the same data type as the `groups` variable. This means that the first column of `groups` is interpreted as `layout.pos.row` and the second column as `layout.pos.col`. The relevant code that calculates the position of the grob object is as follows:

```R
  ...

  if (do_groups) {
    ...
    pos  <-  vapply(groups, as.numeric, numeric(NROW(groups)), USE.NAMES  =  FALSE)
    layout  <-  lengths(lapply(groups, unique))
    ...
  } else {
    ...
  }

  ...

  for (i in seq_along(euler_grob$children)) {
    if (NCOL(pos) == 2L) {
      j <- pos[i, 1L]
      k <- pos[i, 2L]
    } else {
      j <- 1L
      k <- pos[i]
    }
    euler_grob$children[[i]]$vp <- grid::viewport(
      layout.pos.row = j,
      layout.pos.col = k,
      xscale = if (xlim[1] == -Inf) c(-1, 1) else xlim,
      yscale = if (ylim[1] == -Inf) c(-1, 1) else ylim,
      name = paste0("panel.vp.", j, ".", k)
    )
  }
```

While the plotting of strips used the `layout` correctly, `strips$groups` was not used properly. Another observation is that the grob layout fills row by row, but strips start plotting from the bottom left. Hence, it's important to reverse the sequence of the left strips.

```R
  ...

  if  (do_strips)  {
    strips  <-  list(gp  =  setup_gpar(opar$strips,  strips,  n_levels),
                   groups  =  groups)
  }  else  {
    strips  <-  NULL
  }

  ...

  # draw strips
  if  (do_strip_top)  {
    strip_top_vp  <-
      grid::viewport(layout.pos.row  =  strip_top_row,
                     layout.pos.col  =  strip_top_col,
                     name  =  "strip.top.vp",
                     layout  = grid::grid.layout(nrow  =  1,  ncol  =  layout[2]))

    lvls  <-  levels(strips$groups[[1]])
    ...
  }

  if  (do_strip_left)  {
    strip_left_vp  <-
      grid::viewport(layout.pos.row  =  strip_left_row,
                     layout.pos.col  =  strip_left_col,
                     name  =  "strip.left.vp",
                     layout  = grid::grid.layout(nrow  =  layout[1],  ncol  =  1))

    lvls  <-  levels(strips$groups[[2]])
    ...
  }
```

Here's the final euler diagram with the fixed strips:

![image](https://github.com/jolars/eulerr/assets/30854075/3e71d816-514c-4331-97ef-2363efc5bae2)
