### PR TITLE
chore(release): v8.1.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "37f78acc4ede42a14eea55edddd8432a6bb3b2f4",
+  "baseline-sha": "83c420f3ca540d5c9a030c48f008f2b0c601119f",
   "release-targets": [
     {
       "path": ".",
-      "version": "8.0.0",
-      "tag": "v8.0.0"
+      "version": "8.1.0",
+      "tag": "v8.1.0"
+    }
+  ],
+  "pending-release-targets": [
+    {
+      "path": ".",
+      "version": "8.1.0",
+      "tag": "v8.1.0"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eulerr
 Title: Area-Proportional Euler and Venn Diagrams
-Version: 8.0.0.9000
+Version: 8.1.0
 Authors@R: c(person("Johan", "Larsson", email = "johan@jolars.co",
                     role = c("aut", "cre", "cph"),
                     comment = c(ORCID = "0000-0002-4029-5945")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# eulerr (development version)
+# eulerr 8.1
 
 ## Highlights
 
@@ -7,6 +7,18 @@ ability to customize the optimizer used to fit the diagram. eulerr is also
 parallelized now, and because the fitting pipeline now runs the full fit in
 several branches (in parallel), this should bring significant speedups for
 larger diagrams.
+
+## Features
+
+- **plotting:** add configurable canvas margin ([`eea3542`](https://github.com/jolars/eulerr/commit/eea354295936f8409debb4914c1d33f9878b94aa))
+- support rotated rectangles and configurable optimizers ([`330e42b`](https://github.com/jolars/eulerr/commit/330e42b6c87226cbc3833c3e99869fe1a7a971c3))
+- add `n_threads` option for parallelizing fits ([`845a54f`](https://github.com/jolars/eulerr/commit/845a54fb53034be8aecde65ee5a0cedbe31d8c29))
+- add `transform` option to fitter ([`f4b99c1`](https://github.com/jolars/eulerr/commit/f4b99c16d10baf5e23263aa81f6ae6efff06dab0)), closes [#96](https://github.com/jolars/eulerr/issues/96)
+
+## Bug fixes
+
+- **plotting:** increase margin around plot to 2 pt ([`3ff50c6`](https://github.com/jolars/eulerr/commit/3ff50c68c204470e5ba2fa6ea0ff486047928a6b))
+- note correct rustc requirement in DESCRIPTION ([`9b05074`](https://github.com/jolars/eulerr/commit/9b0507423c6088c1432390b9b44f448d52351a88))
 
 # eulerr 8.0
 


### PR DESCRIPTION
## [8.1.0](https://github.com/jolars/eulerr/compare/v8.0.0.9000...v8.1.0) (2026-06-30)

## Highlights

This version brings rotated rectangles as a new shape to eulerr, as well as the
ability to customize the optimizer used to fit the diagram. eulerr is also
parallelized now, and because the fitting pipeline now runs the full fit in
several branches (in parallel), this should bring significant speedups for
larger diagrams.

### Features
- **plotting:** add configurable canvas margin ([`eea3542`](https://github.com/jolars/eulerr/commit/eea354295936f8409debb4914c1d33f9878b94aa))
- support rotated rectangles and configurable optimizers ([`330e42b`](https://github.com/jolars/eulerr/commit/330e42b6c87226cbc3833c3e99869fe1a7a971c3))
- add `n_threads` option for parallelizing fits ([`845a54f`](https://github.com/jolars/eulerr/commit/845a54fb53034be8aecde65ee5a0cedbe31d8c29))
- add `transform` option to fitter ([`f4b99c1`](https://github.com/jolars/eulerr/commit/f4b99c16d10baf5e23263aa81f6ae6efff06dab0)), closes [#96](https://github.com/jolars/eulerr/issues/96)

### Bug Fixes
- **plotting:** increase margin around plot to 2 pt ([`3ff50c6`](https://github.com/jolars/eulerr/commit/3ff50c68c204470e5ba2fa6ea0ff486047928a6b))
- note correct rustc requirement in DESCRIPTION ([`9b05074`](https://github.com/jolars/eulerr/commit/9b0507423c6088c1432390b9b44f448d52351a88))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).