### PR TITLE
chore(release): v8.2.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "83c420f3ca540d5c9a030c48f008f2b0c601119f",
+  "baseline-sha": "954e703bfed5fb07af5e60d33854f71b83cf48f8",
   "release-targets": [
     {
       "path": ".",
-      "version": "8.1.0",
-      "tag": "v8.1.0"
+      "version": "8.2.0",
+      "tag": "v8.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "8.1.0",
-      "tag": "v8.1.0"
+      "version": "8.2.0",
+      "tag": "v8.2.0"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eulerr
 Title: Area-Proportional Euler and Venn Diagrams
-Version: 8.1.0.9000
+Version: 8.2.0
 Authors@R: c(person("Johan", "Larsson", email = "johan@jolars.co",
                     role = c("aut", "cre", "cph"),
                     comment = c(ORCID = "0000-0002-4029-5945")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-# eulerr (development version)
+# eulerr 8.2
+
+## Features
+
+- **plotting:** add matched exterior label placement ([`f00e121`](https://github.com/jolars/eulerr/commit/f00e12179e423bedf0787b4b5a3de012d75b9731))
+
+## Bug fixes
+
+- flatten same-direction eulergram compositions ([`2a10b4b`](https://github.com/jolars/eulerr/commit/2a10b4b3f174c022a68c8e024f6037cfbf653630))
+- **plot:** associate region fills by label not position ([`c74896a`](https://github.com/jolars/eulerr/commit/c74896af20c4d1a382743b8ef32f5da48ebc6ec1)), fixes [#134](https://github.com/jolars/eulerr/issues/134)
 
 # eulerr 8.1
 


### PR DESCRIPTION
# eulerr 8.2

## Features

- **plotting:** add matched exterior label placement ([`f00e121`](https://github.com/jolars/eulerr/commit/f00e12179e423bedf0787b4b5a3de012d75b9731))

## Bug fixes

- flatten same-direction eulergram compositions ([`2a10b4b`](https://github.com/jolars/eulerr/commit/2a10b4b3f174c022a68c8e024f6037cfbf653630))
- **plot:** associate region fills by label not position ([`c74896a`](https://github.com/jolars/eulerr/commit/c74896af20c4d1a382743b8ef32f5da48ebc6ec1)), fixes [#134](https://github.com/jolars/eulerr/issues/134)

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).