### PR TITLE
chore(release): v8.3.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "954e703bfed5fb07af5e60d33854f71b83cf48f8",
+  "baseline-sha": "0314818b9b606f6312eb9d126e7f61cb1ea874af",
   "release-targets": [
     {
       "path": ".",
-      "version": "8.2.0",
-      "tag": "v8.2.0"
+      "version": "8.3.0",
+      "tag": "v8.3.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "8.2.0",
-      "tag": "v8.2.0"
+      "version": "8.3.0",
+      "tag": "v8.3.0"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: eulerr
 Title: Area-Proportional Euler and Venn Diagrams
-Version: 8.2.0
+Version: 8.3.0
 Authors@R:
     c(
       person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
-# Unreleased
+# eulerr 8.3
 
 This releases adds exterior set labels and region glyphs as well as upgrades Eunoia to 1.9.0 for rectangle fitting and normalization fixes
+
+## Features
+
+- upgrade to Eunoia 1.9 ([`79ae995`](https://github.com/jolars/eulerr/commit/79ae995d9b52813939b8471f1c6122c8fe5fe95b))
+
+## Bug fixes
+
+- repair two assertions that passed for the wrong reason ([`0dbd3e7`](https://github.com/jolars/eulerr/commit/0dbd3e71c1af58dd73b1c16f29144f61eff60e23))
 
 # eulerr 8.2
 


### PR DESCRIPTION
# eulerr 8.3

This releases adds exterior set labels and region glyphs as well as upgrades Eunoia to 1.9.0 for rectangle fitting and normalization fixes

## Features

- upgrade to Eunoia 1.9 ([`79ae995`](https://github.com/jolars/eulerr/commit/79ae995d9b52813939b8471f1c6122c8fe5fe95b))

## Bug fixes

- repair two assertions that passed for the wrong reason ([`0dbd3e7`](https://github.com/jolars/eulerr/commit/0dbd3e71c1af58dd73b1c16f29144f61eff60e23))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).